### PR TITLE
Added Enhancements for Active Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Recommend setting to the main company phone number.
 `CM_SSO_ACCOUNT`  
 The RightScale account number the Single Sign-On(SSO) Identity Provider(IDP) is configured under.  
 **Reference:** Can be retrieved from the URL of the SSO configuration screen in RightScale Cloud Management: ht&#8203;tps://us-3.rightscale.com/global/enterprises/**54321**/sso  
-**Example:** 12345
+**Example:** 54321
 
 `GRS_ACCOUNT`  
 The account number for the RightScale Organization.  

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Recommend setting to the main company phone number.
 **Example:** 12345
 
 `GRS_ACCOUNT` : The account number for the RightScale Organization.  
-**Reference:** Can be retrieved from the RightScale Governance URL: https://governance.rightscale.com/org/**12345**/accounts/54321/users
+**Reference:** Can be retrieved from the RightScale Governance URL: ht<span>tps://</span>governance.rightscale.com/org/**12345**/accounts/54321/users
 **Example:** 12345
 
 `RS_HOST` : The RightScale host.  
@@ -155,7 +155,7 @@ Used to create new users, add affiliations to the organization, remove affiliati
 **Reference:** [RightScale Docs - Enable OAuth](http://docs.rightscale.com/cm/dashboard/settings/account/enable_oauth)  
 
 `IDP_HREF` : The href of the IdP associated with the users of the Groups.  
-**Reference:** Can be retrieved by copying the link to edit your SSO: https://us-3.rightscale.com/global/enterprises/54321/edit_sso?identity_provider_id=**573** -or via the [RightScale Cloud Management API](http://reference.rightscale.com/api1.5/resources/ResourceIdentityProviders.html#index)  
+**Reference:** Can be retrieved by copying the link to edit your SSO: ht<span>tps://</span>us-3.rightscale.com/global/enterprises/54321/edit_sso?identity_provider_id=**123** and grabbing the ID value at the end -or via the [RightScale Cloud Management API](http://reference.rightscale.com/api1.5/resources/ResourceIdentityProviders.html#index)  
 **Example:** /api/identity_providers/123
 
 `PURGE_USERS` : Set to 'true' to remove user affiliations from RightScale for users that are no longer members of an LDAP group.  

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Used to create new users, add affiliations to the organization, remove affiliati
 **Reference:** [RightScale Docs - Enable OAuth](http://docs.rightscale.com/cm/dashboard/settings/account/enable_oauth)  
 
 `IDP_HREF` : The href of the IdP associated with the users of the Groups.  
-**Reference:** Can be retrieved by copying the link to edit your SSO: ht&#8203;tps://us-3.rightscale.com/global/enterprises/54321/edit_sso?identity_provider_id=**123** and grabbing the ID value at the end -or via the [RightScale Cloud Management API](http://reference.rightscale.com/api1.5/resources/ResourceIdentityProviders.html#index)  
+**Reference:** Can be retrieved by copying the link to edit your SSO: ht&#8203;tps://us-3.rightscale.com/global/enterprises/54321/edit_sso?identity_provider_id=**123** and grabbing the ID value at the end, or via the [RightScale Cloud Management API](http://reference.rightscale.com/api1.5/resources/ResourceIdentityProviders.html#index)  
 **Example:** /api/identity_providers/123
 
 `PURGE_USERS` : Set to 'true' to remove user affiliations from RightScale for users that are no longer members of an LDAP group.  

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It uses native PowerShell on Windows or [PowerShell core](https://github.com/Pow
    * Linux: [https://www.openldap.org/software/download/](https://www.openldap.org/software/download/)
    * Windows: [https://www.userbooster.de/en/download/openldap-for-windows.aspx](https://www.userbooster.de/en/download/openldap-for-windows.aspx)
      * Ensure you add the **ClientTools** directory to your `PATH`
-1. For Active Directory, the Active Directory PowerShell module is required.
+1. For Active Directory, installation of the Active Directory PowerShell module is recommended.
 
 ## Important Considerations
 1. The tool will not follow memberships for nested groups. Users must be direct members of the LDAP groups to be synchronized.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,84 @@
 # RightScale LDAP Group Sync Tool
 
 This group sync script is designed to sync groups from an LDAP provider, or Active Directory, to RightScale Governance.
-It uses [PowerShell core](https://github.com/PowerShell/PowerShell) and ldapsearch(Part of [openldap](https://www.openldap.org/software/download/) tools) or [Active Directory PowerShell Module](https://technet.microsoft.com/en-us/library/ee617195.aspx).
+It uses native PowerShell on Windows or [PowerShell core](https://github.com/PowerShell/PowerShell) on Linux and ldapsearch(Part of [openldap](https://www.openldap.org/software/download/) tools) or the [Active Directory PowerShell Module](https://technet.microsoft.com/en-us/library/ee617195.aspx).
+
+## Prerequisites
+1. Native PowerShell on Windows or [PowerShell core](https://github.com/PowerShell/PowerShell) on Linux
+1. For a non-Active Directory LDAP Directory Service, openldap tools are required:  
+   * Linux: [https://www.openldap.org/software/download/](https://www.openldap.org/software/download/)
+   * Windows: [https://www.userbooster.de/en/download/openldap-for-windows.aspx](https://www.userbooster.de/en/download/openldap-for-windows.aspx)
+     * Ensure you add the **ClientTools** directory to your `PATH`
+1. For Active Directory, the Active Directory PowerShell module is required.
 
 ## Important Considerations
 1. The tool will not follow memberships for nested groups. Users must be direct members of the LDAP groups to be synchronized.
 1. Groups must already exist in RightScale with the proper roles assigned. This tool will not create groups.
-1. Once a group is managed by this tool, you will no longer be able to manually make modifications to its members in RightScale Governance. Any changes you make to the group in Governance will be removed once the next group sync is run. Manage the group in your directory service
+1. Once a group is managed by this tool, you will no longer be able to manually make modifications to its members in RightScale Governance. Any changes you make to the group in RightScale Governance will be removed once the next group sync is run. Manage the group in your directory service
 1. The time it takes to do a full sync is directly related to the number of groups and users you are synchronizing. We recommend running it a few times manually to get a good baseline before scheduling it to run on a reoccurring basis. Remember to add a buffer to the schedule to account for latency and additional users and groups that may be added in the future.
+1. We recommend creating a group in RightScale Governance to manage users with the `enterprise_manager` role. It is important that this group is not synchronized from your directory service. This will ensure you have a fail-safe for gaining access to RightScale.
 
-## Active Directory
-If the Active Directory PowerShell module is installed on the server running the script, the values of some parameters will automatically be overridden.  
-Read the parameter details carefully below.  
+## Active Directory(AD)
+1. If your directory service is Active Directory, and you will be running this script on a Microsoft Windows Server, please install the Active Directory PowerShell module so the script can use those cmdlets.
+1. When the Active Directory PowerShell module is installed on the Microsoft Windows Server running this script, the values of some parameters will automatically be overridden. Read the parameter details below carefully.  
 
 ## How It Works
-1. The tool gathers groups from an LDAP directory service based on either a list of groups, or a search string.  
-1. Once the groups are discovered, it collects the necessary details from each member of that group(givenname, surname, mail, phone and principal_uid).  
+1. The tool gathers groups from an LDAP directory service based on a comma separated list of groups. Wildcards are supported in the group names.
+1. Once the groups are discovered, it collects the necessary details from each member of that group(Given name, Surname, Email Address, Phone Number and Principal UID).  
 1. A query is run against your Organization in RightScale to collect all users and determine what users need to be created and removed.  
 1. All new users are created based on the attributes collected from LDAP.  
 1. A query is run against your Organization in RightScale to collect the groups that match your LDAP groups and adjust their membership to match your LDAP groups membership.  
-1. (Optional) And finally, users that are no longer members of your LDAP groups are removed from your RightScale Organization.  
+1. (Optional) Users that are no longer members of your LDAP groups are removed from your RightScale Organization.  
 
 ## Script Differences
-RightScale_Group_Sync-PerUserLookup.ps1 - Performs a single LDAP query per user to collect details.
-RightScale_Group_Sync-PerGroupLookup.ps1 - Performs an LDAP query using a filter of `isMemberOf` scoped to the discovered groups.
+**RightScale_Group_Sync-PerUserLookup.ps1** - Performs a single LDAP query per user to collect details.  
+**RightScale_Group_Sync-PerGroupLookup.ps1** - Performs an LDAP query using a filter of `isMemberOf` scoped to the discovered groups.
 
 ## Parameter Includes File
 As opposed to passing all the parameters in during script execution, you can optionally create a file called `groupsync.config.ps1` in the same path as the group sync script and set some or all of the parameters there.
+
+LDAP Directory Example:
 ```powershell
 # LDAP Connection Details
 $LDAP_HOST = "ldap://ldapserver.acme.com"
 $START_TLS = "true"
 $LDAP_USER = "cn=Directory Manager"
 $LDAP_USER_PASSWORD = "OpenSesame1"
-$BASE_GROUP_DN = "OU=Groups,DC=acme,DC=com"
-$BASE_USER_DN = "OU=People,DC=acme,DC=com"
 
 # LDAP Info
-$COMPANY_NAME = "ACME Corp."
-$DEFAULT_PHONE_NUMBER = "555-867-5309"
+$BASE_GROUP_DN = "OU=Groups,DC=acme,DC=com"
+$BASE_USER_DN = "OU=People,DC=acme,DC=com"
 $GROUP_CLASS = "groupOfNames"
 $USER_CLASS = "person"
 $PRINCIPAL_UID_ATTRIBUTE = "entryUUID"
+$GROUP_SEARCH_STRING = "RightScaleGroup_*,RS_Account_Admins"
+$COMPANY_NAME = "ACME Corp."
+$DEFAULT_PHONE_NUMBER = "555-867-5309"
 $EMAIL_DOMAIN = "acme.com"
-$GROUP_SEARCH_STRING = "RightScaleGroup*" # Partial wild card search
-#$LIST_OF_GROUPS = "RightScaleGroup_Dev_Admins,RightScaleGroup_Dev_Observers" # List of groups to sync
+
+#RightScale Details
+$RS_HOST = "us-3.rightscale.com"
+$CM_SSO_ACCOUNT = "12345"
+$GRS_ACCOUNT = "54321"
+$REFRESH_TOKEN = "abc...123"
+$IDP_HREF = "/api/identity_providers/123"
+$PURGE_USERS = "true"
+```
+
+Active Directory Example:
+```powershell
+# AD Connection Details
+$LDAP_HOST = "dc01.acme.com"
+$LDAP_USER = "acme\directoryuser"
+$LDAP_USER_PASSWORD = "OpenSesame1"
+
+# AD Info
+$BASE_GROUP_DN = "OU=Groups,DC=acme,DC=com"
+$BASE_USER_DN = "OU=People,DC=acme,DC=com"
+$GROUP_SEARCH_STRING = "RightScaleGroup_*,RS_Account_Admins"
+$COMPANY_NAME = "ACME Corp."
+$DEFAULT_PHONE_NUMBER = "555-867-5309"
+$EMAIL_DOMAIN = "acme.com"
 
 #RightScale Details
 $RS_HOST = "us-3.rightscale.com"
@@ -56,76 +90,74 @@ $PURGE_USERS = "true"
 ```
 
 ## Script Parameters
-`LDAP_HOST` : Connection string for LDAP host. 
+`LDAP_HOST` ** : Connection string for LDAP host or FQDN of a Domain Controller for Active Directory. 
 ldap:// for non-secure and ldaps:// for secure.  
 Port number can optionally bet set at the end if using a non-standard port for ldap(389) or ldaps(636).  
-Example LDAP: ldap://ldap.acme.com:1389 or ldaps://ldap.acme.com:1636
-Example AD: The FQDN of the DC you would like to use, dc01.acme.com
+**Example for LDAP:** ldap://ldap.acme.com:1389 or ldaps://ldap.acme.com:1636  
+****Example for AD:** The FQDN of the DC you would like to use, dc01.acme.com
 
-`START_TLS` : Set to true to use StartTLS when connecting to your LDAP server.
-Note: Ignored for Active Directory. Authentication is negotiated by default.
-Possible Values: true, false  
-Default Value: false
+`START_TLS` : Set to true to use StartTLS when connecting to your LDAP server.  
+**Note:** Ignored for Active Directory module. Authentication is negotiated by default.  
+**Possible Values:** true, false  
+**Default Value:** false
 
-`LDAP_USER` : User to bind to the Directory Service as.  
-Example LDAP: cn=Directory Manager 
-Example AD: domain\aduser
+`LDAP_USER` ** : User to bind to the Directory Service as.  
+**Example for LDAP:** cn=Directory Manager  
+****Example for AD:** directoryuser@acme.com
 
 `LDAP_USER_PASSWORD` : Password for the LDAP_USER account.  
 
 `BASE_GROUP_DN` : The base dn for groups in the Directory Service.  
-Example: ou=Groups,DC=acme,DC=com
+**Example:** ou=Groups,DC=acme,DC=com
 
 `BASE_USER_DN` : The base dn for users in the Directory Service. 
-Example: ou=Users,DC=acme,DC=com
+**Example:** ou=Users,DC=acme,DC=com
 
-`GROUP_CLASS` : The Directory Services Object Class for groups of users.
-Note: Ignored for Active Directory. 'Group' is automatically used. 
-Example: groupOfNames or group
+`GROUP_CLASS` ** : The Directory Services Object Class for groups of users.  
+****Note:** Ignored for Active Directory module. 'group' is automatically used.  
+**Example:** groupOfNames or group
 
-`USER_CLASS` : The Directory Services Object Class for users.
-Note: Ignored for Active Directory. 'Person' is automatically used.
-Example: person
+`USER_CLASS` ** : The Directory Services Object Class for users.  
+**Note:** Ignored for Active Directory module. 'person' is automatically used.  
+**Note:** The `USER_CLASS` variable is not used with the "Per User Lookup" script: _RightScale_Group_Sync-PerUserLookup.ps1_
+**Example:** person
 
-`PRINCIPAL_UID_ATTRIBUTE` : The name of the LDAP attribute to use for the RightScale principal_uid.  
-Note: Ignored for Active Directory. SID is automatically used.
-Example: entryUUID or objectSid
+`PRINCIPAL_UID_ATTRIBUTE` ** : The name of the LDAP attribute to use for the RightScale principal_uid.  
+****Note:** Ignored for Active Directory module. 'objectSID' is automatically used.  
+**Reference:** [RightScale Docs - Configuring Single Sign-On (SSO)](http://docs.rightscale.com/platform/guides/configuring_sso/#detailed-instructions-step-2--set-up-attribute-mappings)  
+**Example:** entryUUID or objectSID
 
 `GROUP_SEARCH_STRING` : LDAP search string used to filter groups to sync. Wildcard use is supported.  
-Example: RightScaleGroup*  
-Note: Cannot be used with `LIST_OF_GROUPS`
-
-`LIST_OF_GROUPS` : Comma separated list of Groups to sync.  
-Example: RightScale_Admins,RightScale_Observers  
-Note: Cannot be used with `GROUP_SEARCH_STRING`
+**Example:** RightScaleGroup_*,RS_Account_Admins  
 
 `EMAIL_DOMAIN` : The email domain to filter RightScale users on.  
-Example: acme.com
+**Example:** acme.com
 
-`COMPANY_NAME` : Used to populate the company attribute when creating new users in RightScale.
+`COMPANY_NAME` : Used to populate the company attribute when creating new users in RightScale.  
 
 `DEFAULT_PHONE_NUMBER` : Used when creating a new user in RightScale and their phone number in the LDAP directory is not defined.  
 Recommend setting to the main company phone number.  
-Example: 111-555-1212
+**Example: 111-555-1212**
 
 `CM_SSO_ACCOUNT` : The RightScale account number the Single Sign-On(SSO) Identity Provider(IDP) is configured under.  
-Example:12345
+**Example:** 12345
 
 `GRS_ACCOUNT` : The account number for the RightScale Organization.  
-Example:12345
+**Example:** 12345
 
 `RS_HOST` : The RightScale host.  
-Example: us-3.rightscale.com or us-4.rightscale.com
+**Example:** us-3.rightscale.com or us-4.rightscale.com
 
 `REFRESH_TOKEN` : Refresh token for a RightScale user account that has the Enterprise Manager role.  
 Used to create new users, add affiliations to the organization, remove affiliations to the organization, and modify group memberships.
+**Reference:** 
 
 `IDP_HREF` : The href of the IdP associated with the users of the Groups.  
 Example: /api/identity_providers/123
 
 `PURGE_USERS` : Set to 'true' to remove user affiliations from RightScale for users that are no longer members of an LDAP group.  
-Possible Values: true, false  
-Default Value: false
+**Possible Values:** true, false  
+**Default Value:** false
 
 ## License
 The LDAP Group Sync source code is subject to the MIT license, see the [LICENSE](./LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # RightScale LDAP Group Sync Tool
 
-This group sync script is designed to sync groups from an LDAP provider to RightScale Governance.
-It uses ldapsearch(Part of [openldap](https://www.openldap.org/software/download/) tools) and [PowerShell core](https://github.com/PowerShell/PowerShell).
+This group sync script is designed to sync groups from an LDAP provider, or Active Directory, to RightScale Governance.
+It uses [PowerShell core](https://github.com/PowerShell/PowerShell) and ldapsearch(Part of [openldap](https://www.openldap.org/software/download/) tools) or [Active Directory PowerShell Module](https://technet.microsoft.com/en-us/library/ee617195.aspx).
 
 ## Important Considerations
 1. The tool will not follow memberships for nested groups. Users must be direct members of the LDAP groups to be synchronized.
 1. Groups must already exist in RightScale with the proper roles assigned. This tool will not create groups.
 1. Once a group is managed by this tool, you will no longer be able to manually make modifications to its members in RightScale Governance. Any changes you make to the group in Governance will be removed once the next group sync is run. Manage the group in your directory service
 1. The time it takes to do a full sync is directly related to the number of groups and users you are synchronizing. We recommend running it a few times manually to get a good baseline before scheduling it to run on a reoccurring basis. Remember to add a buffer to the schedule to account for latency and additional users and groups that may be added in the future.
+
+## Active Directory
+If the Active Directory PowerShell module is installed on the server running the script, the values of some parameters will automatically be overridden.  
+Read the parameter details carefully below.  
 
 ## How It Works
 1. The tool gathers groups from an LDAP directory service based on either a list of groups, or a search string.  
@@ -52,34 +56,40 @@ $PURGE_USERS = "true"
 ```
 
 ## Script Parameters
-`LDAP_HOST` : Connection string for LDAP host.  
+`LDAP_HOST` : Connection string for LDAP host. 
 ldap:// for non-secure and ldaps:// for secure.  
 Port number can optionally bet set at the end if using a non-standard port for ldap(389) or ldaps(636).  
-Example: ldap://ldap.acme.com:1389 or ldaps://ldap.acme.com:1636
+Example LDAP: ldap://ldap.acme.com:1389 or ldaps://ldap.acme.com:1636
+Example AD: The FQDN of the DC you would like to use, dc01.acme.com
 
-`START_TLS` : Set to true to use StartTLS when connecting to your LDAP server.  
+`START_TLS` : Set to true to use StartTLS when connecting to your LDAP server.
+Note: Ignored for Active Directory. Authentication is negotiated by default.
 Possible Values: true, false  
 Default Value: false
 
 `LDAP_USER` : User to bind to the Directory Service as.  
-Example: cn=Directory Manager
+Example LDAP: cn=Directory Manager 
+Example AD: domain\aduser
 
-`LDAP_USER_PASSWORD` : Password for the LDAP_USER bind account.  
+`LDAP_USER_PASSWORD` : Password for the LDAP_USER account.  
 
 `BASE_GROUP_DN` : The base dn for groups in the Directory Service.  
 Example: ou=Groups,DC=acme,DC=com
 
-`BASE_USER_DN` : The base dn for users in the Directory Service.  
+`BASE_USER_DN` : The base dn for users in the Directory Service. 
 Example: ou=Users,DC=acme,DC=com
 
-`GROUP_CLASS` : The Directory Services Object Class for groups of users.   
-Example: groupOfNames
+`GROUP_CLASS` : The Directory Services Object Class for groups of users.
+Note: Ignored for Active Directory. 'Group' is automatically used. 
+Example: groupOfNames or group
 
-`USER_CLASS` : The Directory Services Object Class for users.  
+`USER_CLASS` : The Directory Services Object Class for users.
+Note: Ignored for Active Directory. 'Person' is automatically used.
 Example: person
 
 `PRINCIPAL_UID_ATTRIBUTE` : The name of the LDAP attribute to use for the RightScale principal_uid.  
-Example: entryUUID
+Note: Ignored for Active Directory. SID is automatically used.
+Example: entryUUID or objectSid
 
 `GROUP_SEARCH_STRING` : LDAP search string used to filter groups to sync. Wildcard use is supported.  
 Example: RightScaleGroup*  

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ $PURGE_USERS = "true"
 ```
 
 ## Script Parameters
-`LDAP_HOST` ** : Connection string for LDAP host or FQDN of a Domain Controller for Active Directory. 
+`LDAP_HOST` ** : Connection string for LDAP host or FQDN of a Domain Controller for Active Directory.  
 ldap:// for non-secure and ldaps:// for secure.  
 Port number can optionally bet set at the end if using a non-standard port for ldap(389) or ldaps(636).  
 **Example for LDAP:** ldap://ldap.acme.com:1389 or ldaps://ldap.acme.com:1636  
 ****Example for AD:** The FQDN of the DC you would like to use, dc01.acme.com
 
 `START_TLS` : Set to true to use StartTLS when connecting to your LDAP server.  
-**Note:** Ignored for Active Directory module. Authentication is negotiated by default.  
+****Note:** Ignored for Active Directory module. Authentication is negotiated by default.  
 **Possible Values:** true, false  
 **Default Value:** false
 
@@ -140,20 +140,23 @@ Recommend setting to the main company phone number.
 **Example: 111-555-1212**
 
 `CM_SSO_ACCOUNT` : The RightScale account number the Single Sign-On(SSO) Identity Provider(IDP) is configured under.  
+**Reference:** Can be retrieved from the URL of the SSO screen: https://us-3.rightscale.com/global/enterprises/**54321**/sso  
 **Example:** 12345
 
 `GRS_ACCOUNT` : The account number for the RightScale Organization.  
+**Reference:** Can be retrieved from the RightScale Governance URL: https://governance.rightscale.com/org/**12345**/accounts/54321/users
 **Example:** 12345
 
 `RS_HOST` : The RightScale host.  
 **Example:** us-3.rightscale.com or us-4.rightscale.com
 
 `REFRESH_TOKEN` : Refresh token for a RightScale user account that has the Enterprise Manager role.  
-Used to create new users, add affiliations to the organization, remove affiliations to the organization, and modify group memberships.
-**Reference:** 
+Used to create new users, add affiliations to the organization, remove affiliations to the organization, and modify group memberships.  
+**Reference:** [RightScale Docs - Enable OAuth](http://docs.rightscale.com/cm/dashboard/settings/account/enable_oauth)  
 
 `IDP_HREF` : The href of the IdP associated with the users of the Groups.  
-Example: /api/identity_providers/123
+**Reference:** Can be retrieved by copying the link to edit your SSO: https://us-3.rightscale.com/global/enterprises/54321/edit_sso?identity_provider_id=**573** -or via the [RightScale Cloud Management API](http://reference.rightscale.com/api1.5/resources/ResourceIdentityProviders.html#index)  
+**Example:** /api/identity_providers/123
 
 `PURGE_USERS` : Set to 'true' to remove user affiliations from RightScale for users that are no longer members of an LDAP group.  
 **Possible Values:** true, false  

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It uses native PowerShell on Windows or [PowerShell core](https://github.com/Pow
 
 ## Script Differences
 **RightScale_Group_Sync-PerUserLookup.ps1** - Performs a single LDAP query per user to collect details.  
-**RightScale_Group_Sync-PerGroupLookup.ps1** - Performs an LDAP query using a filter of `isMemberOf` scoped to the discovered groups.
+**RightScale_Group_Sync-PerGroupLookup.ps1** - Performs an LDAP query using a filter of `isMemberOf`, or `memberOf` for Active Directory, scoped to the discovered groups.
 
 ## Parameter Includes File
 As opposed to passing all the parameters in during script execution, you can optionally create a file called `groupsync.config.ps1` in the same path as the group sync script and set some or all of the parameters there.
@@ -90,6 +90,8 @@ $PURGE_USERS = "true"
 ```
 
 ## Script Parameters
+All parameters are required unless otherwise noted:  
+
 `LDAP_HOST` ** : Connection string for LDAP host or FQDN of a Domain Controller for Active Directory.  
 ldap:// for non-secure and ldaps:// for secure.  
 Port number can optionally bet set at the end if using a non-standard port for ldap(389) or ldaps(636).  
@@ -110,7 +112,8 @@ Port number can optionally bet set at the end if using a non-standard port for l
 `BASE_GROUP_DN` : The base dn for groups in the Directory Service.  
 **Example:** ou=Groups,DC=acme,DC=com
 
-`BASE_USER_DN` : The base dn for users in the Directory Service. 
+`BASE_USER_DN` : The base dn for users in the Directory Service.
+**Note:** The `BASE_USER_DN` variable is not used with the "Per User Lookup" script: _RightScale_Group_Sync-PerUserLookup.ps1_
 **Example:** ou=Users,DC=acme,DC=com
 
 `GROUP_CLASS` ** : The Directory Services Object Class for groups of users.  
@@ -119,7 +122,6 @@ Port number can optionally bet set at the end if using a non-standard port for l
 
 `USER_CLASS` ** : The Directory Services Object Class for users.  
 **Note:** Ignored for Active Directory module. 'person' is automatically used.  
-**Note:** The `USER_CLASS` variable is not used with the "Per User Lookup" script: _RightScale_Group_Sync-PerUserLookup.ps1_
 **Example:** person
 
 `PRINCIPAL_UID_ATTRIBUTE` ** : The name of the LDAP attribute to use for the RightScale principal_uid.  
@@ -140,11 +142,11 @@ Recommend setting to the main company phone number.
 **Example: 111-555-1212**
 
 `CM_SSO_ACCOUNT` : The RightScale account number the Single Sign-On(SSO) Identity Provider(IDP) is configured under.  
-**Reference:** Can be retrieved from the URL of the SSO screen: https://us-3.rightscale.com/global/enterprises/**54321**/sso  
+**Reference:** Can be retrieved from the URL of the SSO configuration screen in RightScale Cloud Management: ht&#8203;tps://us-3.rightscale.com/global/enterprises/**54321**/sso  
 **Example:** 12345
 
 `GRS_ACCOUNT` : The account number for the RightScale Organization.  
-**Reference:** Can be retrieved from the RightScale Governance URL: ht<span>tps://</span>governance.rightscale.com/org/**12345**/accounts/54321/users
+**Reference:** Can be retrieved from the RightScale Governance URL: ht&#8203;tps://governance.rightscale.com/org/**12345**/accounts/54321/users  
 **Example:** 12345
 
 `RS_HOST` : The RightScale host.  
@@ -155,7 +157,7 @@ Used to create new users, add affiliations to the organization, remove affiliati
 **Reference:** [RightScale Docs - Enable OAuth](http://docs.rightscale.com/cm/dashboard/settings/account/enable_oauth)  
 
 `IDP_HREF` : The href of the IdP associated with the users of the Groups.  
-**Reference:** Can be retrieved by copying the link to edit your SSO: ht<span>tps://</span>us-3.rightscale.com/global/enterprises/54321/edit_sso?identity_provider_id=**123** and grabbing the ID value at the end -or via the [RightScale Cloud Management API](http://reference.rightscale.com/api1.5/resources/ResourceIdentityProviders.html#index)  
+**Reference:** Can be retrieved by copying the link to edit your SSO: ht&#8203;tps://us-3.rightscale.com/global/enterprises/54321/edit_sso?identity_provider_id=**123** and grabbing the ID value at the end -or via the [RightScale Cloud Management API](http://reference.rightscale.com/api1.5/resources/ResourceIdentityProviders.html#index)  
 **Example:** /api/identity_providers/123
 
 `PURGE_USERS` : Set to 'true' to remove user affiliations from RightScale for users that are no longer members of an LDAP group.  

--- a/README.md
+++ b/README.md
@@ -92,75 +92,94 @@ $PURGE_USERS = "true"
 ## Script Parameters
 All parameters are required unless otherwise noted:  
 
-`LDAP_HOST` ** : Connection string for LDAP host or FQDN of a Domain Controller for Active Directory.  
+`LDAP_HOST` **  
+Connection string for LDAP host or FQDN of a Domain Controller for Active Directory.  
 ldap:// for non-secure and ldaps:// for secure.  
 Port number can optionally bet set at the end if using a non-standard port for ldap(389) or ldaps(636).  
 **Example for LDAP:** ldap://ldap.acme.com:1389 or ldaps://ldap.acme.com:1636  
 ****Example for AD:** The FQDN of the DC you would like to use, dc01.acme.com
 
-`START_TLS` : Set to true to use StartTLS when connecting to your LDAP server.  
+`START_TLS`  
+Set to true to use StartTLS when connecting to your LDAP server.  
 ****Note:** Ignored for Active Directory module. Authentication is negotiated by default.  
 **Possible Values:** true, false  
 **Default Value:** false
 
-`LDAP_USER` ** : User to bind to the Directory Service as.  
+`LDAP_USER` **  
+User to bind to the Directory Service as.  
 **Example for LDAP:** cn=Directory Manager  
 ****Example for AD:** directoryuser@acme.com
 
-`LDAP_USER_PASSWORD` : Password for the LDAP_USER account.  
+`LDAP_USER_PASSWORD`  
+Password for the LDAP_USER account.  
 
-`BASE_GROUP_DN` : The base dn for groups in the Directory Service.  
+`BASE_GROUP_DN`  
+The base dn for groups in the Directory Service.  
 **Example:** ou=Groups,DC=acme,DC=com
 
-`BASE_USER_DN` : The base dn for users in the Directory Service.
-**Note:** The `BASE_USER_DN` variable is not used with the "Per User Lookup" script: _RightScale_Group_Sync-PerUserLookup.ps1_
+`BASE_USER_DN`  
+The base dn for users in the Directory Service.  
+**Note:** The `BASE_USER_DN` variable is not used with the "Per User Lookup" script: _RightScale_Group_Sync-PerUserLookup.ps1_  
 **Example:** ou=Users,DC=acme,DC=com
 
-`GROUP_CLASS` ** : The Directory Services Object Class for groups of users.  
-****Note:** Ignored for Active Directory module. 'group' is automatically used.  
+`GROUP_CLASS` **  
+The Directory Services Object Class for groups of users.  
+****Note:** Ignored for Active Directory module. The class 'group' is automatically used.  
 **Example:** groupOfNames or group
 
-`USER_CLASS` ** : The Directory Services Object Class for users.  
-**Note:** Ignored for Active Directory module. 'person' is automatically used.  
+`USER_CLASS` **  
+The Directory Services Object Class for users.  
+****Note:** Ignored for Active Directory module. The class 'person' is automatically used.  
 **Example:** person
 
-`PRINCIPAL_UID_ATTRIBUTE` ** : The name of the LDAP attribute to use for the RightScale principal_uid.  
+`PRINCIPAL_UID_ATTRIBUTE` **  
+The name of the LDAP attribute to use for the RightScale principal_uid.  
 ****Note:** Ignored for Active Directory module. 'objectSID' is automatically used.  
 **Reference:** [RightScale Docs - Configuring Single Sign-On (SSO)](http://docs.rightscale.com/platform/guides/configuring_sso/#detailed-instructions-step-2--set-up-attribute-mappings)  
 **Example:** entryUUID or objectSID
 
-`GROUP_SEARCH_STRING` : LDAP search string used to filter groups to sync. Wildcard use is supported.  
+`GROUP_SEARCH_STRING`  
+LDAP search string used to filter groups to sync. Wildcard use is supported.  
 **Example:** RightScaleGroup_*,RS_Account_Admins  
 
-`EMAIL_DOMAIN` : The email domain to filter RightScale users on.  
+`EMAIL_DOMAIN`  
+The email domain to filter RightScale users on.  
 **Example:** acme.com
 
-`COMPANY_NAME` : Used to populate the company attribute when creating new users in RightScale.  
+`COMPANY_NAME`  
+Used to populate the company attribute when creating new users in RightScale.  
 
-`DEFAULT_PHONE_NUMBER` : Used when creating a new user in RightScale and their phone number in the LDAP directory is not defined.  
+`DEFAULT_PHONE_NUMBER`  
+Used when creating a new user in RightScale and their phone number in the LDAP directory is not defined.  
 Recommend setting to the main company phone number.  
 **Example: 111-555-1212**
 
-`CM_SSO_ACCOUNT` : The RightScale account number the Single Sign-On(SSO) Identity Provider(IDP) is configured under.  
+`CM_SSO_ACCOUNT`  
+The RightScale account number the Single Sign-On(SSO) Identity Provider(IDP) is configured under.  
 **Reference:** Can be retrieved from the URL of the SSO configuration screen in RightScale Cloud Management: ht&#8203;tps://us-3.rightscale.com/global/enterprises/**54321**/sso  
 **Example:** 12345
 
-`GRS_ACCOUNT` : The account number for the RightScale Organization.  
+`GRS_ACCOUNT`  
+The account number for the RightScale Organization.  
 **Reference:** Can be retrieved from the RightScale Governance URL: ht&#8203;tps://governance.rightscale.com/org/**12345**/accounts/54321/users  
 **Example:** 12345
 
-`RS_HOST` : The RightScale host.  
+`RS_HOST`  
+The RightScale host.  
 **Example:** us-3.rightscale.com or us-4.rightscale.com
 
-`REFRESH_TOKEN` : Refresh token for a RightScale user account that has the Enterprise Manager role.  
+`REFRESH_TOKEN`  
+Refresh token for a RightScale user account that has the Enterprise Manager role.  
 Used to create new users, add affiliations to the organization, remove affiliations to the organization, and modify group memberships.  
 **Reference:** [RightScale Docs - Enable OAuth](http://docs.rightscale.com/cm/dashboard/settings/account/enable_oauth)  
 
-`IDP_HREF` : The href of the IdP associated with the users of the Groups.  
+`IDP_HREF`  
+The href of the IdP associated with the users of the Groups.  
 **Reference:** Can be retrieved by copying the link to edit your SSO: ht&#8203;tps://us-3.rightscale.com/global/enterprises/54321/edit_sso?identity_provider_id=**123** and grabbing the ID value at the end, or via the [RightScale Cloud Management API](http://reference.rightscale.com/api1.5/resources/ResourceIdentityProviders.html#index)  
 **Example:** /api/identity_providers/123
 
-`PURGE_USERS` : Set to 'true' to remove user affiliations from RightScale for users that are no longer members of an LDAP group.  
+`PURGE_USERS`  
+Set to 'true' to remove user affiliations from RightScale for users that are no longer members of an LDAP group.  
 **Possible Values:** true, false  
 **Default Value:** false
 

--- a/RightScale_Group_Sync-PerGroupLookup.ps1
+++ b/RightScale_Group_Sync-PerGroupLookup.ps1
@@ -1,10 +1,10 @@
 #!/usr/bin/env powershell
 # ---
-# RightScript Name: RightScale Group Sync
+# RightScript Name: RightScale Group Sync - Per Group Lookup
 # Description: >
 #   Synchronizes members of a LDAP directory service with RightScale Governance Groups.
 #   Requires: PowerShell Core and LDAPSEARCH or Active Directory PowerShell Module
-#   If a group is managed by this script, you will be unable to manually add/remove users via Governance.
+#   If a group is managed by this script, you will be unable to manually add/remove users via RightScale Governance.
 # Inputs:
 #   COMPANY_NAME:
 #     Category: RIGHTSCALE
@@ -106,13 +106,7 @@
 #     Default: "text:person"
 #   GROUP_SEARCH_STRING:
 #     Category: LDAP
-#     Description: "LDAP search string to use to filter groups to sync. Wildcard must be added if required. Example: RightScaleGroup*"
-#     Input Type: single
-#     Required: false
-#     Advanced: false
-#   LIST_OF_GROUPS:
-#     Category: LDAP
-#     Description: "Comma separated list of Groups to sync. Example: RightScale_Admins,RightScale_Observers"
+#     Description: "Comma separated list of Groups to sync. Wildcards are supported. Example: RightScaleGroup_*,RS_Account_Admins"
 #     Input Type: single
 #     Required: false
 #     Advanced: false
@@ -174,7 +168,6 @@ param(
     $GROUP_CLASS = $ENV:GROUP_CLASS, # The Directory Services Object Class for groups of users. Example: groupOfNames
     $USER_CLASS = $ENV:USER_CLASS, # The Directory Services Object Class for users. Example: person
     $GROUP_SEARCH_STRING = $ENV:GROUP_SEARCH_STRING, # LDAP search string to use to filter groups to sync. Wildcard must be added if required. Example: RightScaleGroup*
-    $LIST_OF_GROUPS = $ENV:LIST_OF_GROUPS, # Comma separated list of Groups to sync. Example: RightScale_Admins,RightScale_Observers
     $PRINCIPAL_UID_ATTRIBUTE = $ENV:PRINCIPAL_UID_ATTRIBUTE, # The name of the LDAP attribute to use for the RightScale principal_uid
     $EMAIL_DOMAIN = $ENV:EMAIL_DOMAIN, # The email domain to filter RightScale users on. Example: email.com
     $PURGE_USERS = $ENV:PURGE_USERS # Set to 'true' to remove user affiliations from RightScale that are no longer members of an LDAP group
@@ -201,7 +194,7 @@ if(Test-Path $logFilePath) {
 ## Functions
 function Write-Log ($Message, [switch]$OutputToConsole) {
     if(-not(Test-Path -Path $logFilePath)) {
-        New-Item -Path $logFilePath -ItemType "File" > $null
+        New-Item -Path $logFilePath -ItemType "File" -Force > $null
     }
     
     $currentTime = Get-Date -Format "dd-MM-yyyy HH:mm:ss z"
@@ -285,8 +278,9 @@ function New-RSUser ($RSHost, $AccessToken, $GRSAccount, $Email, $FirstName, $La
         }
     }
     catch {
-        Write-Log -Message "Error creating $Email! $($_ | Out-String)" -OutputToConsole
-        New-RSAuditEntry -RSHost $RSHost -AccessToken $AccessToken -Auditee $auditeeHref -Summary "RS Group Sync: Error creating user: $Email!" -Detail ($_ | Out-String)
+        Write-Log -Message "Error creating new RightScale user: $Email! $($_ | Out-String)" -OutputToConsole
+        New-RSAuditEntry -RSHost $RSHost -AccessToken $AccessToken -Auditee $auditeeHref -Summary "RS Group Sync: Error creating new RightScale user: $Email!" -Detail ($_ | Out-String)
+        RETURN $false
     }
 }
 
@@ -341,26 +335,37 @@ function Remove-RSUser ($RSHost, $AccessToken, $GRSAccount, $UserID, $Email) {
             "Authorization"="Bearer $AccessToken"
         }
         
-        $deleteResult = Invoke-WebRequest -UseBasicParsing -Uri "https://$RSHost/grs/orgs/$GRSAccount/users/$UserID" -Method Delete -Headers $grsHeader -ContentType $contentType
+        $deleteResult = Invoke-WebRequest -UseBasicParsing -Uri "https://$RSHost/grs/orgs/$GRSAccount/users/$UserID" -Method Delete -Headers $grsHeader -ContentType $contentType -ErrorAction SilentlyContinue -ErrorVariable deleteResultVariable
 
         if ($deleteResult.StatusCode -eq 204) {
             Write-Log -Message "Successfully removed $Email (RS ID: $UserId) affiliation!" -OutputToConsole
+            New-RSAuditEntry -RSHost $RSHost -AccessToken $AccessToken -Auditee $auditeeHref -Summary "RS Group Sync: Successfully removed $Email affiliation!" -Detail "RightScale User ID: $UserId"
             RETURN $true
         }
         else {
             Write-Log -Message "Error removing $Email (RS ID: $UserId) affiliation! Status Code: $($deleteResult.StatusCode)" -OutputToConsole
+            New-RSAuditEntry -RSHost $RSHost -AccessToken $AccessToken -Auditee $auditeeHref -Summary "RS Group Sync: Error removing $Email affiliation!" -Detail "$deleteResultVariable `nStatus Code: $($deleteResult.StatusCode)`n`n$($deleteResult.RawContent)"
             RETURN $false
         }
     }
     catch {
-        Write-Log -Message "Error removing $Email (RS ID: $UserId) affiliation! $($_ | Out-String)" -OutputToConsole
-        New-RSAuditEntry -RSHost $RSHost -AccessToken $AccessToken -Auditee $auditeeHref -Summary "RS Group Sync: Error removing $Email affiliation!" -Detail ($_ | Out-String)
+        Write-Log -Message "Error removing $Email (RS ID: $UserId) affiliation! Error: $($_.ErrorDetails.ToString())" -OutputToConsole
+        New-RSAuditEntry -RSHost $RSHost -AccessToken $AccessToken -Auditee $auditeeHref -Summary "RS Group Sync: Error removing $Email affiliation!" -Detail ($_.ErrorDetails.ToString())
+        RETURN $false
     }
 }
 
 
 ## Main
 Write-Log -Message "Group Sync Starting..." -OutputToConsole
+
+# Look for config file and if exists, use to set parameters
+$parentPath = Split-Path -Parent $PSCommandPath
+$configFile = Join-Path -Path $parentPath -ChildPath "groupsync.config.ps1"
+if(Test-Path $configFile) {
+    Write-Log -Message "Using config file to populate variables: $configFile" -OutputToConsole
+    . $configFile
+}
 
 # Look for Active Directory Module
 if(Get-Module -Name ActiveDirectory -ListAvailable) {
@@ -370,20 +375,12 @@ if(Get-Module -Name ActiveDirectory -ListAvailable) {
     $adCredential = New-Object System.Management.Automation.PSCredential $LDAP_USER,$adSecurePassword
     $memberOfParameter = "memberOf"
     $GROUP_CLASS = "group"
-    $USER_CLASS = "person"
+    $USER_CLASS = "user"
     $PRINCIPAL_UID_ATTRIBUTE = "objectSID"
 }
 else {
     $useADModule = $false
     $memberOfParameter = "isMemberOf"
-}
-
-# Look for config file and if exists, use to set parameters
-$parentPath = Split-Path -Parent $PSCommandPath
-$configFile = Join-Path -Path $parentPath -ChildPath "groupsync.config.ps1"
-if(Test-Path $configFile) {
-    Write-Log -Message "Using config file to populate variables: $configFile" -OutputToConsole
-    . $configFile
 }
 
 # Get access token from CM
@@ -394,7 +391,7 @@ $oauthBody = @{
     "grant_type"="refresh_token";
     "refresh_token"=$REFRESH_TOKEN
 } | ConvertTo-Json
-$oauthResult = Invoke-RestMethod -UseBasicParsing -Uri "https://$RS_HOST/api/oauth2" -Method Post -Headers $oauthHeader -ContentType $contentType -Body $oauthBody
+$oauthResult = Invoke-RestMethod -Uri "https://$RS_HOST/api/oauth2" -Method Post -Headers $oauthHeader -ContentType $contentType -Body $oauthBody
 $accessToken = $oauthResult.access_token
 
 if (-not($accessToken)) {
@@ -416,7 +413,7 @@ New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHre
 $parameterErrors = 0
 $failedParameters = ""
 $sensitiveParameters = "REFRESH_TOKEN","LDAP_USER_PASSWORD"
-$regularParameters = "COMPANY_NAME","DEFAULT_PHONE_NUMBER","CM_SSO_ACCOUNT","GRS_ACCOUNT","RS_HOST","IDP_HREF","LDAP_HOST","LDAP_USER","BASE_GROUP_DN","BASE_USER_DN","GROUP_CLASS","USER_CLASS","PRINCIPAL_UID_ATTRIBUTE","EMAIL_DOMAIN"
+$regularParameters = "COMPANY_NAME","DEFAULT_PHONE_NUMBER","CM_SSO_ACCOUNT","GRS_ACCOUNT","RS_HOST","IDP_HREF","LDAP_HOST","LDAP_USER","BASE_GROUP_DN","BASE_USER_DN","GROUP_CLASS","USER_CLASS","GROUP_SEARCH_STRING","PRINCIPAL_UID_ATTRIBUTE","EMAIL_DOMAIN"
 $parametersToValidate = $regularParameters + $sensitiveParameters
 foreach($parameterToValidate in $parametersToValidate) {
     if (((Get-Variable -Name $parameterToValidate -ValueOnly -ErrorAction SilentlyContinue) -eq "") -or ((Get-Variable -Name $parameterToValidate -ValueOnly -ErrorAction SilentlyContinue) -eq $null)) {
@@ -438,17 +435,6 @@ else{
     $useTLS = ""
 }
 
-if (($GROUP_SEARCH_STRING.Length -eq 0) -and ($LIST_OF_GROUPS.Length -eq 0)) {
-    Write-Log -Message "Either GROUP_SEARCH_STRING or LIST_OF_GROUPS must be defined. Please define one." -OutputToConsole
-    $parameterErrors ++
-    $failedParameters += "GROUP_SEARCH_STRING", "LIST_OF_GROUPS"
-}
-elseif (($GROUP_SEARCH_STRING.Length -gt 0) -and ($LIST_OF_GROUPS.Length -gt 0)) {
-    Write-Log -Message "GROUP_SEARCH_STRING and LIST_OF_GROUPS cannot be used together. Please define one and leave the other blank." -OutputToConsole
-    $parameterErrors ++
-    $failedParameters += "GROUP_SEARCH_STRING", "LIST_OF_GROUPS"
-}
-
 if($parameterErrors -gt 0) {
     $parameterFailureMessage = "The following parameters have failed validation: $failedParameters"
     Write-Log -Message $parameterFailureMessage  -OutputToConsole
@@ -458,56 +444,25 @@ if($parameterErrors -gt 0) {
 }
 
 ## LDAP directory
-# Determine if using list or search string and build the filter
-if ($GROUP_SEARCH_STRING -ne $null) {
-    $groupsFilter = "(&(objectClass=$GROUP_CLASS)(cn=$GROUP_SEARCH_STRING))"
-    Write-Log -Message "Getting all LDAP groups matching '$GROUP_SEARCH_STRING'..." -OutputToConsole
+# Build the groups LDAP filter
+$groupsToFilter = $null
+foreach ($group in $GROUP_SEARCH_STRING.Split(',')) {
+    $groupsToFilter += "(cn=$group)"
 }
-elseif ($LIST_OF_GROUPS -ne $null) {
-    $groupsToFilter = $null
-    foreach ($group in $LIST_OF_GROUPS.Split(',')) {
-        $groupsToFilter += "(cn=$group)"
-    }
-    $groupsFilter = "(&(objectClass=$GROUP_CLASS)(|$groupsToFilter))"
-    Write-Log -Message "Getting all groups matching '$LIST_OF_GROUPS'..." -OutputToConsole
-}
-else {
-    $parameterFailureMessage = "A 'GROUP_SEARCH_STRING' or 'LIST_OF_GROUPS' must be specified!"
-    Write-Log -Message $parameterFailureMessage  -OutputToConsole
-    New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: Parameter validation failure" -Detail $parameterFailureMessage
-    New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: Complete (With Errors)" -Detail (Get-Content -Path $logFilePath | Out-String)
-    EXIT 1
-}
+$groupsFilter = "(&(objectClass=$GROUP_CLASS)(|$groupsToFilter))"
+Write-Log -Message "Getting all groups matching '$GROUP_SEARCH_STRING'..." -OutputToConsole
 
 # Get the LDAP groups
 try {
     $ldapGroups = @()
     if($useADModule) {
         $rawGroups = Get-ADGroup -LDAPFilter $groupsFilter -Credential $adCredential -SearchBase $BASE_GROUP_DN -Server $LDAP_HOST -ErrorVariable ldapGroupLookupError -ErrorAction SilentlyContinue
-        foreach ($group in $rawGroups) {
-            $groupMembers = $group | Get-ADGroupMember -Credential $adCredential -Server $LDAP_HOST | Select-Object -ExpandProperty distinguishedName
-            $object = New-Object -TypeName PSObject
-            $object | Add-Member -MemberType NoteProperty -Name dn -Value $group.DistinguishedName
-            $object | Add-Member -MemberType NoteProperty -Name cn -Value $group.Name
-            $object | Add-Member -MemberType NoteProperty -Name members -Value $groupMembers
-            $ldapGroups += $object
-        }
     }
     else {
         $rawGroups = (Invoke-Expression -Command "ldapsearch -LLL -x -H $LDAP_HOST $useTLS -D '$LDAP_USER' -w '$LDAP_USER_PASSWORD' -b '$BASE_GROUP_DN' '$groupsFilter' dn cn member" -ErrorVariable ldapGroupLookupError -ErrorAction SilentlyContinue) 2>&1
-        $rawGroups = $rawGroups | ForEach-Object {$_.TrimEnd()} | Where-Object {$_ -ne ""} #Remove empty lines
-        $rawGroups = $rawGroups | Where-Object {$_ -notmatch "# ref"} #Needed for Active Directory
-        $rawGroups = $rawGroups -join "`n" -split '(?ms)(?=^dn:)' -match '^dn:' #Split into separate objects
-        foreach ($group in $rawGroups) {
-            $object = New-Object -TypeName PSObject
-            $object | Add-Member -MemberType NoteProperty -Name dn -Value $($group -split '\n' -match '^dn:' -replace 'dn:\s','')
-            $object | Add-Member -MemberType NoteProperty -Name cn -Value $($group -split '\n' -match '^cn:' -replace 'cn:\s','')
-            $object | Add-Member -MemberType NoteProperty -Name members -Value ($group -split '\n' -match '^member:' -replace 'member:\s','')
-            $ldapGroups += $object
-        }
     }
 
-    if($lastexitcode -ne 0) {
+    if(-not($?)) {
         $ldapErrorMessage = "Error retrieving groups from LDAP!"
         Write-Log "$ldapErrorMessage Error: $ldapGroupLookupError" -OutputToConsole
         New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: $ldapErrorMessage" -Detail ($ldapGroupLookupError | Out-String)
@@ -521,6 +476,29 @@ try {
         New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: Complete (With Errors)" -Detail (Get-Content -Path $logFilePath | Out-String)
         EXIT 1
     }
+    
+    if($useADModule) {
+        foreach ($group in $rawGroups) {
+            $groupMembers = $group | Get-ADGroupMember -Credential $adCredential -Server $LDAP_HOST | Select-Object -ExpandProperty distinguishedName
+            $object = New-Object -TypeName PSObject
+            $object | Add-Member -MemberType NoteProperty -Name dn -Value $group.DistinguishedName
+            $object | Add-Member -MemberType NoteProperty -Name cn -Value $group.Name
+            $object | Add-Member -MemberType NoteProperty -Name members -Value $groupMembers
+            $ldapGroups += $object
+        }
+    }
+    else {
+        $rawGroups = $rawGroups | ForEach-Object {$_.TrimEnd()} | Where-Object {$_ -ne ""} #Remove empty lines
+        $rawGroups = $rawGroups | Where-Object {$_ -notmatch "# ref"} #Needed for Active Directory
+        $rawGroups = $rawGroups -join "`n" -split '(?ms)(?=^dn:)' -match '^dn:' #Split into separate objects
+        foreach ($group in $rawGroups) {
+            $object = New-Object -TypeName PSObject
+            $object | Add-Member -MemberType NoteProperty -Name dn -Value $($group -split '\n' -match '^dn:' -replace 'dn:\s','')
+            $object | Add-Member -MemberType NoteProperty -Name cn -Value $($group -split '\n' -match '^cn:' -replace 'cn:\s','')
+            $object | Add-Member -MemberType NoteProperty -Name members -Value ($group -split '\n' -match '^member:' -replace 'member:\s','')
+            $ldapGroups += $object
+        }
+    }
 }
 catch {
     $ldapErrorMessage = "Error retrieving groups from LDAP!"
@@ -530,9 +508,9 @@ catch {
     EXIT 1
 }
 Write-Log -Message "$($ldapGroups.Count) LDAP Group(s) found." -OutputToConsole
- 
+
 # Build user LDAP filter
-# Potentially expensive query, alternative is to do a single search per user dn, or get all LDAP users and do a client side filter
+# Potentially expensive query, the alternative is to do a single search per user dn.
 $groupsToFilter = $null
 foreach ($group in $ldapGroups.dn) {
     $groupsToFilter += "($memberOfParameter=$group)"
@@ -544,45 +522,13 @@ try {
     Write-Log -Message "Getting all members of filtered LDAP groups..." -OutputToConsole
     $ldapUsers = @()
     if($useADModule){
-        $rawUsers = Get-ADObject -LDAPFilter $userFilter -Credential $adCredential -Properties 'surname','givenName','mail','telephoneNumber',$PRINCIPAL_UID_ATTRIBUTE,'objectClass' -SearchBase $BASE_USER_DN -Server $LDAP_HOST -ErrorVariable ldapUserLookupError -ErrorAction SilentlyContinue
-        foreach ($user in $rawUsers) {
-            $phoneNumber = $null
-            $object = New-Object -TypeName PSObject
-            $object | Add-Member -MemberType NoteProperty -Name dn -Value $user.DistinguishedName
-            $object | Add-Member -MemberType NoteProperty -Name sn -Value $user.surname
-            $object | Add-Member -MemberType NoteProperty -Name givenName -Value $user.givenName
-            $object | Add-Member -MemberType NoteProperty -Name email -Value $user.mail
-            $object | Add-Member -MemberType NoteProperty -Name $PRINCIPAL_UID_ATTRIBUTE -Value $user.objectSID.Value
-            $phoneNumber = $user.telephoneNumber
-            if (($phoneNumber -eq $null) -or ($phoneNumber.length -eq 0) -or ($phoneNumber -notmatch '^[\.()\s\d+-]+$')) {
-                $phoneNumber = $DEFAULT_PHONE_NUMBER
-            }
-            $object | Add-Member -MemberType NoteProperty -Name telephoneNumber -Value $phoneNumber
-            $ldapUsers += $object
-        }
+        $rawUsers = Get-ADObject -LDAPFilter $userFilter -Credential $adCredential -Properties 'sn','givenName','mail','telephoneNumber',$PRINCIPAL_UID_ATTRIBUTE,'objectClass' -SearchBase $BASE_USER_DN -Server $LDAP_HOST -ErrorVariable ldapUserLookupError -ErrorAction SilentlyContinue  
     }
     else {
         $rawUsers = (Invoke-Expression -Command "ldapsearch -LLL -x -H $LDAP_HOST $useTLS -D '$LDAP_USER' -w '$LDAP_USER_PASSWORD' -b '$BASE_USER_DN' '$userFilter' sn givenName mail telephoneNumber $PRINCIPAL_UID_ATTRIBUTE objectClass" -ErrorVariable ldapUserLookupError -ErrorAction SilentlyContinue) 2>&1
-        $rawUsers = $rawUsers | ForEach-Object {$_.TrimEnd()} | Where-Object {$_ -ne ""} #Remove empty lines
-        $rawUsers = $rawUsers | Where-Object {$_ -notmatch "# ref"} #Needed for Active Directory
-        $rawUsers = $rawUsers -join "`n" -split '(?ms)(?=^dn:)' -match '^dn:' #Split into separate objects
-        foreach ($user in $rawUsers) {
-            $phoneNumber = $null
-            $object = New-Object -TypeName PSObject
-            $object | Add-Member -MemberType NoteProperty -Name dn -Value $($user -split '\n' -match '^dn:' -replace 'dn:\s','')
-            $object | Add-Member -MemberType NoteProperty -Name sn -Value $($user -split '\n' -match '^sn:' -replace 'sn:\s','')
-            $object | Add-Member -MemberType NoteProperty -Name givenName -Value $($user -split '\n' -match '^givenName:' -replace 'givenName:\s','')
-            $object | Add-Member -MemberType NoteProperty -Name email -Value $($user -split '\n' -match '^mail:' -replace 'mail:\s','')
-            $object | Add-Member -MemberType NoteProperty -Name $PRINCIPAL_UID_ATTRIBUTE -Value $($user -split '\n' -match "^$([regex]::Escape($PRINCIPAL_UID_ATTRIBUTE)):" -replace "$([regex]::Escape($PRINCIPAL_UID_ATTRIBUTE)):\s",'')
-            $phoneNumber = $($user -split '\n' -match '^telephoneNumber:' -replace 'telephoneNumber:\s','')
-            if (($phoneNumber -eq $null) -or ($phoneNumber.length -eq 0) -or ($phoneNumber -notmatch '^[\.()\s\d+-]+$')) {
-                $phoneNumber = $DEFAULT_PHONE_NUMBER
-            }
-            $object | Add-Member -MemberType NoteProperty -Name telephoneNumber -Value $phoneNumber
-            $ldapUsers += $object
-        }
     }
-    if($lastexitcode -ne 0) {
+
+    if(-not($?)) {
         $ldapErrorMessage = "Error retrieving users from LDAP!"
         Write-Log "$ldapErrorMessage Error: $ldapUserLookupError" -OutputToConsole
         New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: $ldapErrorMessage" -Detail ($ldapUserLookupError | Out-String)
@@ -596,6 +542,58 @@ try {
         New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: Complete (With Errors)" -Detail (Get-Content -Path $logFilePath | Out-String)
         EXIT 1
     }
+
+    if($useADModule) {
+        foreach ($rawUser in $rawUsers) {
+            $ldapUser = $rawUser.DistinguishedName
+            $objectClass = $rawUser.objectClass
+            if($objectClass -contains $USER_CLASS) {          
+                $phoneNumber = $null
+                $object = New-Object -TypeName PSObject
+                $object | Add-Member -MemberType NoteProperty -Name dn -Value $rawUser.DistinguishedName
+                $object | Add-Member -MemberType NoteProperty -Name sn -Value $rawUser.sn
+                $object | Add-Member -MemberType NoteProperty -Name givenName -Value $rawUser.givenName
+                $object | Add-Member -MemberType NoteProperty -Name email -Value $rawUser.mail
+                $object | Add-Member -MemberType NoteProperty -Name $PRINCIPAL_UID_ATTRIBUTE -Value $rawUser.$PRINCIPAL_UID_ATTRIBUTE.Value
+                $phoneNumber = $rawUser.telephoneNumber
+                if (($phoneNumber -eq $null) -or ($phoneNumber.length -eq 0) -or ($phoneNumber -notmatch '^[\.()\s\d+-]+$')) {
+                    $phoneNumber = $DEFAULT_PHONE_NUMBER
+                }
+                $object | Add-Member -MemberType NoteProperty -Name telephoneNumber -Value $phoneNumber
+                $ldapUsers += $object
+            }
+            else {
+                Write-Log -Message "Object: $ldapUser is not of objectClass $USER_CLASS! objectClass(es): $($objectClass -join ', ')" -OutputToConsole
+            }
+        }
+    }
+    else {
+        $rawUsers = $rawUsers | ForEach-Object {$_.TrimEnd()} | Where-Object {$_ -ne ""} #Remove empty lines
+        $rawUsers = $rawUsers | Where-Object {$_ -notmatch "# ref"} #Needed for Active Directory
+        $rawUsers = $rawUsers -join "`n" -split '(?ms)(?=^dn:)' -match '^dn:' #Split into separate objects
+        foreach ($rawUser in $rawUsers) {
+            $ldapUser = $($rawUser -split '\n' -match '^dn:' -replace 'dn:\s','')
+            $objectClass = $($rawUser -split '\n' -match '^objectClass:' -replace 'objectClass:\s','')
+            if($objectClass -contains $USER_CLASS) {
+                $phoneNumber = $null
+                $object = New-Object -TypeName PSObject
+                $object | Add-Member -MemberType NoteProperty -Name dn -Value $($rawUser -split '\n' -match '^dn:' -replace 'dn:\s','')
+                $object | Add-Member -MemberType NoteProperty -Name sn -Value $($rawUser -split '\n' -match '^sn:' -replace 'sn:\s','')
+                $object | Add-Member -MemberType NoteProperty -Name givenName -Value $($rawUser -split '\n' -match '^givenName:' -replace 'givenName:\s','')
+                $object | Add-Member -MemberType NoteProperty -Name email -Value $($rawUser -split '\n' -match '^mail:' -replace 'mail:\s','')
+                $object | Add-Member -MemberType NoteProperty -Name $PRINCIPAL_UID_ATTRIBUTE -Value $($rawUser -split '\n' -match "^$([regex]::Escape($PRINCIPAL_UID_ATTRIBUTE)):" -replace "$([regex]::Escape($PRINCIPAL_UID_ATTRIBUTE)):\s",'')
+                $phoneNumber = $($rawUser -split '\n' -match '^telephoneNumber:' -replace 'telephoneNumber:\s','')
+                if (($phoneNumber -eq $null) -or ($phoneNumber.length -eq 0) -or ($phoneNumber -notmatch '^[\.()\s\d+-]+$')) {
+                    $phoneNumber = $DEFAULT_PHONE_NUMBER
+                }
+                $object | Add-Member -MemberType NoteProperty -Name telephoneNumber -Value $phoneNumber
+                $ldapUsers += $object
+            }
+            else {
+                Write-Log -Message "Object: $ldapUser is not of objectClass $USER_CLASS! objectClass(es): $($objectClass -join ', ')" -OutputToConsole
+            }
+        }
+    }
 }
 catch {
     $ldapErrorMessage = "Error retrieving users from LDAP!"
@@ -604,16 +602,12 @@ catch {
     New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: Complete (With Errors)" -Detail (Get-Content -Path $logFilePath | Out-String)
     EXIT 1
 }
-
-# Create LDAP users object
-$ldapUsers = @()
-
 Write-Log -Message "$($ldapUsers.Count) LDAP User(s) found." -OutputToConsole
 
 ## RightScale Governance
 # Get RightScale users
 Write-Log -Message "Getting All RightScale Users... " -OutputToConsole
-$rsGRSUsers = Invoke-RestMethod -UseBasicParsing -Uri "https://$RS_HOST/grs/orgs/$GRS_ACCOUNT/users" -Method Get -Headers $grsHeader -ContentType $contentType
+$rsGRSUsers = Invoke-RestMethod -Uri "https://$RS_HOST/grs/orgs/$GRS_ACCOUNT/users" -Method Get -Headers $grsHeader -ContentType $contentType
 if(-not($rsGRSUsers)) {
     Write-Log -Message "Error retrieving users from RightScale!" -OutputToConsole
     New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: Complete (With Errors)" -Detail (Get-Content -Path $logFilePath | Out-String)
@@ -658,8 +652,8 @@ if($usersToCreate.count -gt 0){
     }
 
     # Create audit entry for users created and not created
-    $usersCreatedDetails = "Users created successfully:`n$($newUsersCreated | Out-String)"
-    $usersCreatedDetails += "Users NOT created successfully:`n$($newUsersNotCreated | Out-String)"
+    $usersCreatedDetails = "Users created successfully:$($newUsersCreated | Format-List | Out-String)"
+    $usersCreatedDetails += "Users NOT created successfully:$($newUsersNotCreated | Format-List | Out-String)"
     New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: User(s) Created" -Detail $usersCreatedDetails
 }
 else {
@@ -676,7 +670,7 @@ if($newUsersCreated.count -gt 0) {
 
 # Get RightScale groups
 Write-Log -Message "Getting All RightScale Groups..." -OutputToConsole
-$rsGRSGroups = Invoke-RestMethod -UseBasicParsing -Uri "https://$RS_HOST/grs/orgs/$GRS_ACCOUNT/groups" -Method Get -Headers $grsHeader -ContentType $contentType
+$rsGRSGroups = Invoke-RestMethod -Uri "https://$RS_HOST/grs/orgs/$GRS_ACCOUNT/groups" -Method Get -Headers $grsHeader -ContentType $contentType
 if(-not($rsGRSGroups)) {
     Write-Log -Message "Error retrieving groups from RightScale!" -OutputToConsole
     New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: Complete (With Errors)" -Detail (Get-Content -Path $logFilePath | Out-String)
@@ -688,6 +682,7 @@ Write-Log -Message "$($rsGRSGroups.Count) RightScale Group(s) found." -OutputToC
 # Replaces the Users in a Group. If an empty list of Users is passed in the request, then all the Users are removed from the Group given in the request.
 Write-Log -Message "Determining group memberships and updating..." -OutputToConsole
 foreach ($ldapGroup in $ldapGroups) {
+    $prunedMembers = @()
     $group = $null
     $group = $rsGRSGroups | Where-Object { $_.name -eq $ldapGroup.cn }
     if ($group -ne $null) {
@@ -696,7 +691,8 @@ foreach ($ldapGroup in $ldapGroups) {
         $group_id = $group.id
         Write-Log -Message "Group: $group_name (RS ID: $group_id)" -OutputToConsole
         if($ldapGroup.members.count -gt 0) {
-            foreach ($member in $ldapGroup.members) {
+            $prunedMembers = Compare-Object -ReferenceObject $ldapgroup.members -DifferenceObject $ldapUsers.dn -IncludeEqual -ExcludeDifferent | Select-Object -ExpandProperty InputObject
+            foreach ($member in $prunedMembers) {
                 $user_id = $null
                 $user_email = $null
                 $user_email = $ldapUsers | Where-Object { $_.dn -eq $member } | Select-Object -ExpandProperty email
@@ -742,8 +738,8 @@ if($usersToDelete.count -gt 0){
             }
         }
         # Create audit entry for users removed and not removed
-        $usersDeletedDetails = "Users removed successfully:`n$($usersDeleted | Out-String)`n"
-        $usersDeletedDetails += "Users NOT removed successfully:`n$($usersNotDeleted | Out-String)`n"
+        $usersDeletedDetails = "Users removed successfully:$($usersDeleted | Format-List | Out-String)"
+        $usersDeletedDetails += "Users NOT removed successfully:$($usersNotDeleted | Format-List | Out-String)"
         New-RSAuditEntry -RSHost $RS_HOST -AccessToken $accessToken -Auditee $auditeeHref -Summary "RS Group Sync: User(s) Removed" -Detail $usersDeletedDetails
     }
     else {


### PR DESCRIPTION
Updated the script to use the Active Directory PowerShell module, if available and using Windows Server, to query against a Domain Controller.

Removed the `LIST_OF_GROUPS` parameter and merged the functionality into `GROUP_SEARCH_STRING`. So you can now provide a comma separated list of groups and the use of wildcards is allowed.

Updated the readme with all pertinent information. Be sure to read it through to the end.