### PR TITLE
Add details to readme for using as a RightScript and using on a schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $task | Set-ScheduledTask
 Assumptions:
 * The script has the execute permission set
 * `PATH` is available in crontab.
-* A [parameter includes file](#Parameter-Includes-File) is stored in the same path 
+* A [parameter includes file](#parameter-includes-file) is stored in the same path 
 as the script with all parameters defined.  
 
 This example executes the Group Sync Script every 15 minutes:
@@ -129,7 +129,7 @@ This example executes the Group Sync Script every 15 minutes:
 ## Executing as a standalone script via a Scheduled Task in Windows
 Assumptions:
 * The downloaded script has been [unblocked](https://blogs.msdn.microsoft.com/delay/p/unblockingdownloadedfile/)
-* A [parameter includes file](#Parameter_Includes_File) is stored in the same path 
+* A [parameter includes file](#parameter-includes-file) is stored in the same path 
 as the script with all parameters defined.  
 
 This example creates a scheduled task that executes the Group Sync Script every 15 minutes:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,65 @@ $IDP_HREF = "/api/identity_providers/123"
 $PURGE_USERS = "true"
 ```
 
+## Executing as a RightScript
+The script uses [RightScript metadata comments](http://docs.rightscale.com/cm/dashboard/design/rightscripts/rightscripts_metadata_comments.html) to define the parameters. This allows the script to be easily added to RightScale Cloud management for execution on a RightLink managed server.
+
+Executing the script as RightScript on a RightLink managed server allows you to make use of RightScale [credentials](http://docs.rightscale.com/cm/dashboard/design/credentials/index.html) to safely store the value for the sensitive parameters referenced in executing this script.
+
+You can also schedule the execution of the RightScript from the managed servers scheduling utility. Here is an example of some code that would setup a scheduled task on a Windows server to run the Per User Group Sync script, against Active Directory, every 15 minutes using RightScale credentials for the `LDAP_USER_PASSWORD` and `REFRESH_TOKEN` parameters.
+```powershell
+$jobname = "RightScale AD Group Sync"
+
+## Define the arguments for RSC and the script
+$script = "rl10 run_right_script /rll/run/right_script `"right_script_id=0123456789`" `"arguments=LDAP_HOST=text:dc01.acme.com`" `"arguments=LDAP_USER=text:directoryuser@acme.com`" `"arguments=LDAP_USER_PASSWORD=cred:Active_Directory_User_Password`" `"arguments=BASE_GROUP_DN=text:ou=Groups,DC=acme,DC=com`" `"arguments=GROUP_CLASS=text:group`" `"arguments=USER_CLASS=text:person`" `"arguments=PRINCIPAL_UID_ATTRIBUTE=text:objectSID`" `"arguments=GROUP_SEARCH_STRING=text:RightScaleGroup_* `" `"arguments=COMPANY_NAME=text:Acme Co.`" `"arguments=DEFAULT_PHONE_NUMBER=text:111-555-1212`" `"arguments=EMAIL_DOMAIN=text:acme.com`" `"arguments=RS_HOST=text:us-3.rightscale.com`" `"arguments=CM_SSO_ACCOUNT=text:54321`" `"arguments=GRS_ACCOUNT=text:12345`" `"arguments=REFRESH_TOKEN=cred:RightScale_Governance_Refresh_Token`" `"arguments=IDP_HREF=text:/api/identity_providers/123`" `"arguments=START_TLS=text:false`" `"arguments=PURGE_USERS=text:false`""
+
+## Run every 'n' minutes
+$repeat = (New-TimeSpan -Minutes 15)
+
+$action = New-ScheduledTaskAction –Execute "C:\Program Files\RightScale\RightLink\rsc.exe" -Argument $script
+$duration = New-TimeSpan -Days 3650
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).Date -RepetitionInterval $repeat -RepetitionDuration $duration
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RunOnlyIfNetworkAvailable -DontStopOnIdleEnd
+$task = Register-ScheduledTask -TaskName $jobname -Action $action -Trigger $trigger -RunLevel Highest -User "NT AUTHORITY\SYSTEM" -Settings $settings
+$task.Triggers.repetition.Duration = "" ## Setting duration to an empty string == 'indefinitely'
+$task.Triggers.repetition.StopAtDurationEnd = "False"
+$task | Set-ScheduledTask
+```
+
+## Executing as a standalone script via a cronjob in Linux
+Assumptions:
+* The script has the execute permission set
+* `PATH` is available in crontab.
+* A [parameter includes file](#Parameter-Includes-File) is stored in the same path 
+as the script with all parameters defined.  
+
+This example executes the Group Sync Script every 15 minutes:
+```shell
+*/15 * * * * /path/to/script/rightscale_group_sync.ps1
+```
+
+## Executing as a standalone script via a Scheduled Task in Windows
+Assumptions:
+* The downloaded script has been [unblocked](https://blogs.msdn.microsoft.com/delay/p/unblockingdownloadedfile/)
+* A [parameter includes file](#Parameter_Includes_File) is stored in the same path 
+as the script with all parameters defined.  
+
+This example creates a scheduled task that executes the Group Sync Script every 15 minutes:
+```powershell
+$jobname = "RightScale Group Sync"
+$script = "-ExecutionPolicy Bypass c:\path\to\script\rightscale_group_sync.ps1"
+
+$repeat = (New-TimeSpan -Minutes 15)
+$action = New-ScheduledTaskAction –Execute "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -Argument $script
+$duration = New-TimeSpan -Days 3650
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).Date -RepetitionInterval $repeat -RepetitionDuration $duration
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RunOnlyIfNetworkAvailable -DontStopOnIdleEnd
+$task = Register-ScheduledTask -TaskName $jobname -Action $action -Trigger $trigger -RunLevel Highest -User "NT AUTHORITY\SYSTEM" -Settings $settings
+$task.Triggers.repetition.Duration = ""
+$task.Triggers.repetition.StopAtDurationEnd = "False"
+$task | Set-ScheduledTask
+```
+
 ## Script Parameters
 All parameters are required unless otherwise noted:  
 
@@ -148,11 +207,12 @@ The email domain to filter RightScale users on.
 
 `COMPANY_NAME`  
 Used to populate the company attribute when creating new users in RightScale.  
+**Example:** Acme Co.
 
 `DEFAULT_PHONE_NUMBER`  
 Used when creating a new user in RightScale and their phone number in the LDAP directory is not defined.  
 Recommend setting to the main company phone number.  
-**Example: 111-555-1212**
+**Example:** 111-555-1212
 
 `CM_SSO_ACCOUNT`  
 The RightScale account number the Single Sign-On(SSO) Identity Provider(IDP) is configured under.  

--- a/RightScale_Group_Sync-PerGroupLookup.ps1
+++ b/RightScale_Group_Sync-PerGroupLookup.ps1
@@ -175,14 +175,6 @@ param(
 
 $errorActionPreference = 'stop'
 
-# crontab information
-# ensure script has execute permission set
-# ensure PATH is available in crontab
-# use config file (groupsync.config.ps1), stored in the same path 
-# as the script, to set the inputs and keep them out of crontab.
-# to run every 15 minutes:
-# */15 * * * * /path/to/script/rightscale_group_sync.ps1
-
 # Define log file
 $logFilePath = "/tmp/rightscale_group_sync.log"
 

--- a/RightScale_Group_Sync-PerUserLookup.ps1
+++ b/RightScale_Group_Sync-PerUserLookup.ps1
@@ -167,14 +167,6 @@ param(
 
 $errorActionPreference = 'stop'
 
-# crontab information
-# ensure script has execute permission set
-# ensure PATH is available in crontab
-# use config file (groupsync.config.ps1), stored in the same path 
-# as the script, to set the inputs and keep them out of crontab.
-# to run every 15 minutes:
-# */15 * * * * /path/to/script/rightscale_group_sync.ps1
-
 # Define log file
 $logFilePath = "/tmp/rightscale_group_sync.log"
 


### PR DESCRIPTION
Added details around executing as a RightScript, scheduling as a standlone script on Linux and windows and also removed crontab details from scripts themselves.