### PR TITLE
Updates for multiple domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RightScale LDAP Group Sync Tool
 
+:exclamation: *NOTE for Active Directory: This branch uses the distinguished name of each user to construct the FQDN of the domain to query with the `Get-ADObject` command. When using the FQDN of a domain as the the value for the `-Server` paramter, there is no guarantee which Domain Controller it will contact.*
+
 This group sync script is designed to sync groups from an LDAP provider, or Active Directory, to RightScale Governance.
 It uses native PowerShell on Windows or [PowerShell core](https://github.com/PowerShell/PowerShell) on Linux and ldapsearch(Part of [openldap](https://www.openldap.org/software/download/) tools) or the [Active Directory PowerShell Module](https://technet.microsoft.com/en-us/library/ee617195.aspx).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RightScale LDAP Group Sync Tool
 
-:exclamation: *NOTE for Active Directory: This branch uses the distinguished name of each user to construct the FQDN of the domain to query with the `Get-ADObject` command. When using the FQDN of a domain as the the value for the `-Server` paramter, there is no guarantee which Domain Controller it will contact.*
+:exclamation: *NOTE for Active Directory: This branch uses the distinguished name of each user to construct the FQDN of the domain to query with the `Get-ADObject` command. When using the FQDN of a domain as the the value for the `-Server` parameter, there is no guarantee which Domain Controller it will contact.*
 
 This group sync script is designed to sync groups from an LDAP provider, or Active Directory, to RightScale Governance.
 It uses native PowerShell on Windows or [PowerShell core](https://github.com/PowerShell/PowerShell) on Linux and ldapsearch(Part of [openldap](https://www.openldap.org/software/download/) tools) or the [Active Directory PowerShell Module](https://technet.microsoft.com/en-us/library/ee617195.aspx).

--- a/RightScale_Group_Sync.ps1
+++ b/RightScale_Group_Sync.ps1
@@ -130,7 +130,7 @@
 # ...
 
 #
-# Version: 2.0
+# Version: 2.0.1
 #
 
 # Copyright 2017 RightScale

--- a/RightScale_Group_Sync.ps1
+++ b/RightScale_Group_Sync.ps1
@@ -510,7 +510,8 @@ foreach ($ldapUser in $allLDAPRSUsers) {
     try {
         Write-Log -Message "Getting user details for '$ldapUser'..." -OutputToConsole
         if($useADModule) {
-            $rawUser = Get-ADObject -Identity $ldapUser -Credential $adCredential -Properties 'sn','givenName','mail','telephoneNumber',$PRINCIPAL_UID_ATTRIBUTE,'objectClass' -Server $LDAP_HOST -ErrorVariable ldapUserLookupError -ErrorAction SilentlyContinue
+            $domainFQDN = ($ldapUser -Split "," | Where-Object {$_ -like "DC=*"}) -join '.' -replace 'DC=', ''
+            $rawUser = Get-ADObject -Identity $ldapUser -Credential $adCredential -Properties 'sn','givenName','mail','telephoneNumber',$PRINCIPAL_UID_ATTRIBUTE,'objectClass' -Server $domainFQDN -ErrorVariable ldapUserLookupError -ErrorAction SilentlyContinue
         }
         else {
             $rawUser = (Invoke-Expression -Command "ldapsearch -LLL -x -H $LDAP_HOST $useTLS -D '$LDAP_USER' -w '$LDAP_USER_PASSWORD' -s base -b '$ldapUser' sn givenName mail telephoneNumber $PRINCIPAL_UID_ATTRIBUTE objectClass" -ErrorVariable ldapUserLookupError -ErrorAction SilentlyContinue) 2>&1


### PR DESCRIPTION
This branch uses the distinguished name of each user to construct the FQDN of the domain to query with the `Get-ADObject` command. When using the FQDN of a domain as the the value for the `-Server` parameter, there is no guarantee which Domain Controller it will contact.